### PR TITLE
Simplified first stage fit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ Icon?
 .RData
 .Rproj.user/
 
+# Generated documentation files
+man/
+docs/pkgdown.yml
+
 # data folders
 data/
 output/

--- a/R/cox-methods.R
+++ b/R/cox-methods.R
@@ -54,6 +54,11 @@ hapr_survfit <- function(fit,
     cumhaz <- cumhaz[keep_idx, , drop = FALSE]
     surv <- surv[keep_idx, , drop = FALSE]
     surv <- surv / matrix(surv_t0, nrow = length(time), ncol = length(surv_t0), byrow = TRUE)
+
+    # Insert start.time with survival = 1
+    time <- c(start.time, time)
+    surv <- rbind(rep(1, length(relative_risk)), surv)
+    if (exists("cumhaz")) cumhaz <- rbind(NA, cumhaz)
   }
 
   result <- list()

--- a/R/hapr_stage_1.R
+++ b/R/hapr_stage_1.R
@@ -28,12 +28,7 @@ hapr_first_stage <- function(y, gc, w, model_type) {
   } else if (model_type == "probit") {
     regression_function <- function(data) strip_probit(glm(y ~ ., data = data, family = binomial(link = "probit")))
   } else if (model_type == "cox") {
-    regression_function <- function(data) {
-      full_model <- survival::coxph(y ~ ., data = data)
-      stripped <- strip_cox(full_model)
-      stripped$model <- full_model  # <-- Add full model for vcov()
-      stripped
-    }
+    regression_function <- function(data) strip_cox(survival::coxph(y ~ ., data = data))
   } else {
     stop("Unsupported model_type: ", model_type)
   }
@@ -43,8 +38,7 @@ hapr_first_stage <- function(y, gc, w, model_type) {
     gc_on_w = strip_lm(lm(gc ~ ., data = w)),
     y_on_w = regression_function(w),
     y_on_gc = regression_function(data.frame(gc = gc)),
-    y_on_gc_w = regression_function(cbind(gc = gc, w)),
-    y_on_gf_w = regression_function(cbind(gf = gc, w))
+    y_on_gc_w = regression_function(cbind(gc = gc, w))
   )
   
   # Extract coefficients
@@ -55,7 +49,7 @@ hapr_first_stage <- function(y, gc, w, model_type) {
     vcov_gamma = {
       if (model_type == "cox") {
         # Use full Cox model for vcov
-        vcov(regressions$y_on_gc_w$model)
+        regressions$y_on_gc_w$vcov_coefficients
       } else {
         regressions$y_on_gc_w$vcov_coefficients
       }

--- a/R/hapr_stage_2.R
+++ b/R/hapr_stage_2.R
@@ -116,9 +116,13 @@ hapr_second_stage <- function(
     check.names = FALSE
   )
 
-  # Update stripped model
-  first_stage$regressions$y_on_gf_w$stripped_model$coefficients <- beta
-  first_stage$regressions$y_on_gc_w$coefficients <- beta
+  # Create model for y_on_gf_w
+  y_on_gf_w <- first_stage$regressions$y_on_gc_w
+
+  # Update model coefficients
+  y_on_gf_w$coefficients <- beta
+  y_on_gf_w$vcov_coefficients <- vcov_beta
+  y_on_gf_w$stripped_model$coefficients <- beta
 
   additional_parameters <- list()
   if (first_stage$model_type == "lm") {
@@ -129,19 +133,60 @@ hapr_second_stage <- function(
       beta["gf"]^2 * posterior$c^2 / 2 + beta["gf"] * theta_intercept * posterior$b
     )
 
-    baseline_hazard <- first_stage$regressions$y_on_gf_w$baseline_hazard
+    baseline_hazard <- first_stage$regressions$y_on_gc_w$baseline_hazard
     baseline_hazard$hazard <- baseline_hazard$hazard / base_hazard_conversion_ratio
 
-    first_stage$regressions$y_on_gf_w$baseline_hazard <- baseline_hazard
-    first_stage$regressions$y_on_gf_w$stripped_model$baseline_hazard <- baseline_hazard
+    y_on_gf_w$baseline_hazard <- baseline_hazard
 
     additional_parameters$base_hazard_conversion_ratio <- base_hazard_conversion_ratio
     additional_parameters$baseline_hazard <- baseline_hazard
   }
 
+  # Clean up not needed parts of y_on_gf_w based on model type
+  if (first_stage$model_type == "cox") {
+    y_on_gf_w$stripped_model$var <- NULL
+    y_on_gf_w$stripped_model$iter <- NULL
+    y_on_gf_w$stripped_model$means <- NULL
+    y_on_gf_w$stripped_model$method <- NULL
+    y_on_gf_w$stripped_model$assign <- NULL
+    y_on_gf_w$stripped_model$timefix <- NULL
+    y_on_gf_w$stripped_model$formula <- NULL
+    y_on_gf_w$stripped_model$xlevels <- NULL
+    y_on_gf_w$stripped_model$contrasts <- NULL
+    y_on_gf_w$stripped_model$formula <- NULL
+  } else if (first_stage$model_type == "lm") {
+    y_on_gf_w$stripped_model$rank <- NULL
+    y_on_gf_w$stripped_model$assign <- NULL
+    y_on_gf_w$stripped_model$qr <- NULL
+    y_on_gf_w$stripped_model$df.residual <- NULL
+    y_on_gf_w$stripped_model$contrasts <- NULL
+    y_on_gf_w$stripped_model$xlevels <- NULL
+    y_on_gf_w$stripped_model$call <- NULL
+    y_on_gf_w$stripped_model$terms <- NULL
+  } else if (first_stage$model_type == "probit") {
+    y_on_gf_w$stripped_model$R <- NULL
+    y_on_gf_w$stripped_model$rank <- NULL
+    y_on_gf_w$stripped_model$deviance <- NULL
+    y_on_gf_w$stripped_model$aic <- NULL
+    y_on_gf_w$stripped_model$null.deviance <- NULL
+    y_on_gf_w$stripped_model$iter <- NULL
+    y_on_gf_w$stripped_model$df.residual <- NULL
+    y_on_gf_w$stripped_model$df.null <- NULL
+    y_on_gf_w$stripped_model$converged <- NULL
+    y_on_gf_w$stripped_model$boundary <- NULL
+    y_on_gf_w$stripped_model$call <- NULL
+    y_on_gf_w$stripped_model$formula <- NULL
+    y_on_gf_w$stripped_model$terms <- NULL
+    y_on_gf_w$stripped_model$offset <- NULL
+    y_on_gf_w$stripped_model$control <- NULL
+    y_on_gf_w$stripped_model$contrasts <- NULL
+    y_on_gf_w$stripped_model$xlevels <- NULL
+    y_on_gf_w$stripped_model$qr <- NULL
+  }
+
   result <- list(
     model_type = first_stage$model_type,
-    regressions = first_stage$regressions,
+    regressions = c(first_stage$regressions, list(y_on_gf_w = y_on_gf_w)),
     coefficients = c(first_stage$coefficients, list(beta = beta)),
     standard_errors = sd_beta,
     vcov_beta = vcov_beta,

--- a/R/predict.R
+++ b/R/predict.R
@@ -65,9 +65,56 @@ predict.hapr_fit <- function(object, newdata, covariates = c("w", "gc_w", "gf_w"
       } else {
         stop("For Cox models, `type` must be 'lp', 'response', or 'risk'.")
       }
-    } else {
-      # Use standard `predict` for 'lm' or 'probit'
-      results[[paste0("y_hat_", cov)]] <- predict(model_obj, newdata = newdata, type = type)
+    } else if (fit$model_type == "lm") {
+      # Manual prediction for lm models
+      # Validate type for lm models
+      if (type != "response") {
+        stop("For lm models, `type` must be 'response'.")
+      }
+      
+      # 1. Extract coefficients
+      if (!"coefficients" %in% names(model_obj)) {
+        stop(sprintf("The stripped lm model for '%s' has no 'coefficients'.", cov))
+      }
+      coefs <- model_obj$coefficients
+
+      # 2. Build model matrix (handles factors automatically)
+      X <- model.matrix(~., data = newdata)
+
+      # 3. Compute linear predictor from matching columns
+      common_vars <- intersect(names(coefs), colnames(X))
+      X_sub <- X[, common_vars, drop = FALSE]
+      Xbeta <- as.vector(X_sub %*% coefs)
+
+      # 4. For lm, the response is the same as the linear predictor
+      results[[paste0("y_hat_", cov)]] <- Xbeta
+    } else if (fit$model_type == "probit") {
+      # Manual prediction for probit models
+      # Validate type for probit models
+      if (!type %in% c("response", "link")) {
+        stop("For probit models, `type` must be 'response' or 'link'.")
+      }
+      
+      # 1. Extract coefficients
+      if (!"coefficients" %in% names(model_obj)) {
+        stop(sprintf("The stripped probit model for '%s' has no 'coefficients'.", cov))
+      }
+      coefs <- model_obj$coefficients
+
+      # 2. Build model matrix (handles factors automatically)
+      X <- model.matrix(~., data = newdata)
+
+      # 3. Compute linear predictor from matching columns
+      common_vars <- intersect(names(coefs), colnames(X))
+      X_sub <- X[, common_vars, drop = FALSE]
+      Xbeta <- as.vector(X_sub %*% coefs)
+
+      # 4. Determine what to return based on type
+      if (type == "link") {
+        results[[paste0("y_hat_", cov)]] <- Xbeta
+      } else if (type == "response") {
+        results[[paste0("y_hat_", cov)]] <- pnorm(Xbeta)
+      }
     }
   }
 

--- a/R/strippers.R
+++ b/R/strippers.R
@@ -49,7 +49,7 @@ strip_lm <- function(fit) {
   fit$residuals <- NULL
   fit$fitted.values <- NULL
   fit$effects <- NULL
-  fit$qr$qr <- NULL
+  fit$qr <- NULL
   fit$weights <- NULL
 
   # Return everything in a clean list
@@ -106,6 +106,10 @@ strip_probit <- function(fit) {
   fit$effects <- NULL
   fit$qr$qr <- NULL
   fit$weights <- NULL
+  fit$qr <- NULL
+  fit$linear.predictors <- NULL
+  fit$data <- NULL
+  fit$prior.weights <- NULL
 
   # Return simplified object
   list(

--- a/tests/testthat/_snaps/hapr-linear.md
+++ b/tests/testthat/_snaps/hapr-linear.md
@@ -1,0 +1,22 @@
+# hapr print output is stable (linear)
+
+    Code
+      print(fit)
+    Output
+      🐵  HAPR (Heritability Adjusted Prediction) Model  🐵 
+      -------------------------------------------
+      Model type: lm 
+      
+      Beta coefficients (future PRS effects):
+                  Estimate
+      (Intercept) -0.04468
+      gf           0.44025
+      w1           0.19992
+      w2B          0.03719
+      w2C          0.06579
+      
+      Improvement ratio: 1.5000 ( improvement_ratio )
+      R² current: 0.1327 ( first_stage )
+      R² future: 0.1991 
+      Max improvement ratio: 3.1196 
+

--- a/tests/testthat/_snaps/hapr-probit.md
+++ b/tests/testthat/_snaps/hapr-probit.md
@@ -1,0 +1,22 @@
+# hapr print output is stable (probit)
+
+    Code
+      print(fit)
+    Output
+      🐵  HAPR (Heritability Adjusted Prediction) Model  🐵 
+      -------------------------------------------
+      Model type: probit 
+      
+      Beta coefficients (future PRS effects):
+                  Estimate
+      (Intercept)  0.07107
+      gf           0.74332
+      w1          -0.31427
+      w2B         -0.11204
+      w2C         -0.41058
+      
+      Improvement ratio: 1.5000 ( improvement_ratio )
+      R² current: 0.0859 ( first_stage )
+      R² future: 0.1288 
+      Max improvement ratio: 3.6942 
+

--- a/tests/testthat/test-hapr-probit.R
+++ b/tests/testthat/test-hapr-probit.R
@@ -245,3 +245,55 @@ test_that("hapr confidence intervals for beta achieve exact match coverage (prob
               info = paste("Coverage below threshold:\n",
                            paste(coverage_df$Term, coverage_df$Coverage, collapse = "\n")))
 })
+
+# ---- PSEUDO-R2 CALCULATION TEST ----
+test_that("pseudo-R2 from predict() matches manual calculation (probit)", {
+  # Use existing helper function
+  data <- simulate_mock_dataset(n = 1000)
+  
+  # Fit the hapr model
+  fit <- hapr(
+    y = data$y,
+    gc = data$gc,
+    w = data$w,
+    model_type = "probit",
+    r2_future = 0.31
+  )
+
+  # Simulate data
+  sim_data <- hapr_simulate(fit, w = data$w, gc = data$gc)
+
+  # Make predictions
+  pred <- predict(fit, newdata = sim_data, covariates = "gf_w", type = "link")
+  y_hat_gf_w <- pred$y_hat_gf_w
+
+  # Calculate pseudo-R2 from predict function
+  pseudo_r2_predict <- var(y_hat_gf_w) / (1 + var(y_hat_gf_w))
+
+  # Manual calculation using the full formula
+  beta_vec <- fit$coefficients$beta
+  beta_w <- beta_vec[names(beta_vec) != "gf"]
+  beta_gf <- beta_vec["gf"]
+
+  # Get variance-covariance matrix of w
+  w_matrix <- model.matrix(~., data = data$w)
+  var_w <- var(w_matrix[, -1])  # Remove intercept
+
+  # Calculate covariance between gf and w
+  gf_sim <- sim_data$gf
+  cov_gf_w <- cov(gf_sim, w_matrix[, -1])
+
+  # Manual calculation
+  beta_w_aligned <- beta_w[colnames(var_w)]
+  cov_gf_w_col <- t(as.matrix(cov_gf_w))
+
+  var_L_hat_gf_w <- 
+    var(gf_sim) * beta_gf^2 +
+    as.numeric(t(beta_w_aligned) %*% var_w %*% beta_w_aligned) + 
+    2 * beta_gf * as.numeric(t(beta_w_aligned) %*% cov_gf_w_col)
+
+  pseudo_r2_manual <- var_L_hat_gf_w / (1 + var_L_hat_gf_w)
+
+  # Test that the two calculations match
+  expect_equal(pseudo_r2_predict, as.numeric(pseudo_r2_manual), tolerance = 1e-10)
+})


### PR DESCRIPTION
Previously hapr first stage made unnecessary regression that was saved for gf. Now this is no longer even created in the first stage. We still create the object in the second stage, but now just copying from the already stripped regression object from the feasible regression on gc.

Also organized the regressions and stripping better.

Another commit here solves a small bug on hapr survfit when producing coditional survival curves. The bug only failed a single test randomly.